### PR TITLE
Hotfix: non-existent endpoints should return not found (404)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fcd",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fcd",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6587,11 +6587,6 @@
         }
       }
     },
-    "koa-add-trailing-slashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/koa-add-trailing-slashes/-/koa-add-trailing-slashes-2.0.1.tgz",
-      "integrity": "sha512-mCH5Pm7xkfwHN2qhpSARq1HV0XZ7WOSDGbED079oZN/azHOTcJBy8EtiICcuFu/zblPg67IISF6mT/RDmLdCHA=="
-    },
     "koa-body": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/koa-body/-/koa-body-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcd",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Terra FCD API Server",
   "main": "index.js",
   "author": "Terra Engineering <engineering@terra.money>",
@@ -74,7 +74,6 @@
     "got": "^11",
     "http-proxy": "^1.18.0",
     "koa": "^2.7.0",
-    "koa-add-trailing-slashes": "^2.0.1",
     "koa-body": "^4.1.0",
     "koa-helmet": "^5",
     "koa-joi-controllers": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcd",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Terra FCD API Server",
   "main": "index.js",
   "author": "Terra Engineering <engineering@terra.money>",

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -7,7 +7,6 @@ import * as cors from '@koa/cors'
 import * as helmet from 'koa-helmet'
 import * as serve from 'koa-static'
 import * as mount from 'koa-mount'
-import * as addTrailingSlashes from 'koa-add-trailing-slashes'
 import { configureRoutes } from 'koa-joi-controllers'
 
 import config from 'config'
@@ -41,7 +40,7 @@ function getApiDocApp(): Koa {
   // static
   const app = new Koa()
 
-  app.use(addTrailingSlashes()).use(
+  app.use(
     serve(path.resolve(__dirname, '..', 'static'), {
       maxage: 86400 * 1000
     })

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -21,6 +21,10 @@ const koaSwagger = require('koa2-swagger-ui')
 
 const API_VERSION_PREFIX = '/v1'
 
+const notFoundMiddleware: Koa.Middleware = (ctx) => {
+  ctx.status = 404
+}
+
 function getRootApp(): Koa {
   // root app only contains the health check route
   const app = new Koa()
@@ -36,30 +40,68 @@ function getRootApp(): Koa {
   return app
 }
 
-function getApiDocApp(): Koa {
+function createApiDocApp(): Koa {
   // static
   const app = new Koa()
 
-  app.use(
-    serve(path.resolve(__dirname, '..', 'static'), {
-      maxage: 86400 * 1000
-    })
-  )
+  app
+    .use(
+      serve(path.resolve(__dirname, '..', 'static'), {
+        maxage: 86400 * 1000
+      })
+    )
+    .use(notFoundMiddleware)
+
   return app
 }
 
-function getSwaggerApp(): Koa {
+function createSwaggerApp(): Koa {
   // swagger ui
   const app = new Koa()
 
-  app.use(
-    koaSwagger({
-      routePrefix: '/',
-      swaggerOptions: {
-        url: '/static/swagger.json'
-      }
+  app
+    .use(
+      koaSwagger({
+        routePrefix: '/',
+        swaggerOptions: {
+          url: '/static/swagger.json'
+        }
+      })
+    )
+    .use(notFoundMiddleware)
+
+  return app
+}
+
+function createAPIApp(): Koa {
+  const app = new Koa()
+
+  app
+    .use(errorHandler(error))
+    .use(async (ctx, next) => {
+      await next()
+
+      ctx.set('Cache-Control', 'no-store, no-cache, must-revalidate')
+      ctx.set('Pragma', 'no-cache')
+      ctx.set('Expires', '0')
     })
-  )
+    .use(
+      bodyParser({
+        formLimit: '512kb',
+        jsonLimit: '512kb',
+        textLimit: '512kb',
+        multipart: true,
+        onError: (error) => {
+          throw new APIError(ErrorTypes.INVALID_REQUEST_ERROR, '', error.message, error)
+        }
+      })
+    )
+
+  // add controllers
+  configureRoutes(app, controllers)
+
+  app.use(notFoundMiddleware)
+
   return app
 }
 
@@ -74,43 +116,22 @@ export default async (disableAPI: boolean = false): Promise<Koa> => {
 
   logger.info('Adding REST API')
   app.proxy = true
-  const apiDocApp = getApiDocApp()
-  const swaggerApp = getSwaggerApp()
+
+  const apiDocApp = createApiDocApp()
+  const swaggerApp = createSwaggerApp()
+  const apiApp = createAPIApp()
 
   app
     .use(morgan('common'))
     .use(helmet())
+    .use(cors())
     .use(mount('/static', apiDocApp))
     .use(mount('/apidoc', apiDocApp))
     .use(mount('/swagger', swaggerApp))
-    .use(errorHandler(error))
-    .use(async (ctx, next) => {
-      await next()
+    .use(mount(API_VERSION_PREFIX, apiApp))
 
-      ctx.set('Cache-Control', 'no-store, no-cache, must-revalidate')
-      ctx.set('Pragma', 'no-cache')
-      ctx.set('Expires', '0')
-    })
-    .use(cors())
-    .use(
-      bodyParser({
-        formLimit: '512kb',
-        jsonLimit: '512kb',
-        textLimit: '512kb',
-        multipart: true,
-        onError: (error) => {
-          throw new APIError(ErrorTypes.INVALID_REQUEST_ERROR, '', error.message, error)
-        }
-      })
-    )
-
-  // add API
-  configureRoutes(app, controllers, API_VERSION_PREFIX)
-
-  // routes && init
-  const router = new Router()
-  router.all(
-    '(.*)',
+  // proxy to lcd
+  app.use(
     proxy({
       host: config.BYPASS_URI,
       changeOrigin: true,
@@ -120,9 +141,6 @@ export default async (disableAPI: boolean = false): Promise<Koa> => {
       }
     })
   )
-
-  app.use(router.routes())
-  app.use(router.allowedMethods())
 
   return app
 }


### PR DESCRIPTION
## Description
FCD server passes all of non-existent and unknown endpoints to LCD. Such endpoints starting with /static, /apidoc and /v1 should return Not Found (404) immediately.

## Changes
* removed koa-add-trailing-slashes
* separate app for API endpoints starting with /v1
* added notFoundMiddleware for returning 404 response

## Further step
It would be ideal if we specify all LCD endpoints to be proxied.
