### PR TITLE
Fix interval price

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcd",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Terra FCD API Server",
   "main": "index.js",
   "author": "Terra Engineering <engineering@terra.money>",

--- a/src/controller/MarketController.ts
+++ b/src/controller/MarketController.ts
@@ -34,7 +34,7 @@ export default class MarketController extends KoaController {
     query: {
       interval: Joi.string().required().valid(Object.values(TimeIntervals)).description('Time interval'),
       denom: Joi.string().required().valid(config.ACTIVE_DENOMS).description('Denoms string'),
-      count: Joi.string().min(0).max(1000).default(50).description('Price data points count')
+      count: Joi.number().min(0).max(1000).default(50).description('Price data points count')
     },
     failure: ErrorCodes.INVALID_REQUEST_ERROR
   })

--- a/src/service/market/getPrice.ts
+++ b/src/service/market/getPrice.ts
@@ -44,10 +44,10 @@ async function getPriceAvg(params: GetPriceParams): Promise<PriceByInterval[]> {
   const minTimeStamp = latestTimestamp - msc * params.count
 
   const subTimeQ = `trunc((((
-    DATE_PART('day', '${getQueryDateTime(now)}'::timestamp - datetime::timestamp) * 24 
-    + DATE_PART('hour', '${getQueryDateTime(now)}'::timestamp - datetime::timestamp)) * 60
-    + DATE_PART('minute', '${getQueryDateTime(now)}'::timestamp - datetime::timestamp)) * 60 
-    + DATE_PART('second', '${getQueryDateTime(now)}'::timestamp - datetime::timestamp))/(${intervalInSec}))`
+    DATE_PART('day', '${getQueryDateTime(maxTimeStamp)}'::timestamp - datetime::timestamp) * 24 
+    + DATE_PART('hour', '${getQueryDateTime(maxTimeStamp)}'::timestamp - datetime::timestamp)) * 60
+    + DATE_PART('minute', '${getQueryDateTime(maxTimeStamp)}'::timestamp - datetime::timestamp)) * 60 
+    + DATE_PART('second', '${getQueryDateTime(maxTimeStamp)}'::timestamp - datetime::timestamp))/(${intervalInSec}))`
 
   const rawQ = `select denom, avg(price.price) as price, min(datetime) as datetime, ${subTimeQ} as time_div 
     from price where denom = '${params.denom}' and datetime >= '${getQueryDateTime(minTimeStamp)}' 


### PR DESCRIPTION
## Fix validation

 `count` query params should be `number` rather `string` in `/market/price` API

## Take average price in each time segment interval

 **Current**: Now FCD select price from table using sql **In()** query for each time interval. which select a single row from each time segment. for interval of `1m` one minute it is correct as it contains one entry per minutes. 

 **Issue**: For large interval price history like **`15m`-> `Fifteen minutes`**, **`1h`-> `One hour`** or **`1d` -> `One day`** taking a single value mislead the price information. Cause price might move to several direction in the whole time interval. 

 **Expected**: For large interval FCD should choose the average price of a given interval segment.  

 **Solution**: aggregation by multiple time range segment in a single query is not possible in sql native query. To achieve this, time diff in seconds with the current time is calculated and divided with time interval in seconds. the integer part of the division is the segment which the price entity falls into. Then doing avg aggregation based on the price based on the time segment will provide the expected result.