### PR TITLE
Add gas price API

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ module.exports = {
 | DISABLE_API         | Disable REST APIs               | false                                        | API                                |
 | DISABLE_SOCKET      | Dsiable Web Socket              | false                                        | API                                |
 | EXCLUDED_ROUTES     | List of regular expression string for excluding routes | []                    | API                                |
+| MIN_GAS_PRICES      | Minimum gas price by denom object| {"uluna": "0.015", "usdr": "0.015", "uusd": "0.015", "ukrw": "0.015", "umnt": "0.015"}                    | API                                |
 
 
 > In Terra, we use [direnv](https://direnv.net) for managing environment variable for development. See [sample of .envrc](.envrc_sample)

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import { string } from 'yargs'
+
 const {
   SERVER_PORT,
   CHAIN_ID,
@@ -15,7 +17,8 @@ const {
   ACTIVE_CURRENCY,
   DISABLE_API,
   DISABLE_SOCKET,
-  EXCLUDED_ROUTES
+  EXCLUDED_ROUTES,
+  MIN_GAS_PRICES
 } = process.env
 
 const config = {
@@ -46,7 +49,16 @@ const config = {
     ? (JSON.parse(EXCLUDED_ROUTES) as string[]).map((regExp) => new RegExp(regExp))
     : [
         /* /\/wasm\// */
-      ]
+      ],
+  MIN_GAS_PRICES: MIN_GAS_PRICES
+    ? (JSON.parse(MIN_GAS_PRICES) as CoinByDenoms)
+    : ({
+        uluna: '0.015',
+        usdr: '0.015',
+        uusd: '0.015',
+        ukrw: '0.015',
+        umnt: '0.015'
+      } as CoinByDenoms)
 }
 
 export default config

--- a/src/controller/TransactionController.ts
+++ b/src/controller/TransactionController.ts
@@ -314,4 +314,19 @@ export default class TransactionController extends KoaController {
       })
     )
   }
+  /**
+   * @api {get} /txs/gas_prices Get gas prices
+   * @apiName getGasPrices
+   * @apiGroup Transactions
+   *
+   * @apiSuccess {string} uluna gas price in uluna
+   * @apiSuccess {string} usdr gas price in usdr
+   * @apiSuccess {string} uusd gas price in uusd
+   * @apiSuccess {string} ukrw gas price in ukrw
+   * @apiSuccess {string} umnt gas price in umnt
+   */
+  @Get('/txs/gas_prices')
+  async getGasPrices(ctx): Promise<void> {
+    success(ctx, config.MIN_GAS_PRICES)
+  }
 }

--- a/src/e2etest/tx.spec.ts
+++ b/src/e2etest/tx.spec.ts
@@ -263,4 +263,18 @@ describe('Transaction', () => {
     const { body } = await agent.get(`/v1/txs?memo=faucet`).expect(200)
     expect(body.txs.length).toBeGreaterThan(0)
   })
+
+  test('get min gas price', async () => {
+    const { body } = await agent.get(`/v1/txs/gas_prices`).expect(200)
+    expect(body.uluna).toBeDefined()
+    expect(body.uluna).toBeString()
+    expect(body.usdr).toBeDefined()
+    expect(body.usdr).toBeString()
+    expect(body.uusd).toBeDefined()
+    expect(body.uusd).toBeString()
+    expect(body.ukrw).toBeDefined()
+    expect(body.ukrw).toBeString()
+    expect(body.umnt).toBeDefined()
+    expect(body.umnt).toBeString()
+  })
 })


### PR DESCRIPTION
## Description
This PR will expose a new API endpoint `/v1/txs/gas_prices` which returns the min gas prices.

## Specification

### Configuration
You can specify minimum gas prices through MIN_GAS_PRICES environment variable

**Default**
'{"uluna":"0.015","usdr":"0.015","uusd":"0.015","ukrw":"0.015","umnt":"0.015"}'

**Example**
MIN_GAS_PRICES='{"uluna":"0.15","usdr":"0.1018","uusd":"0.15","ukrw":"178.05","umnt":"431.6259"}'

### Endpoint Response
```json
{
  "uluna": "0.015",
  "usdr": "0.015",
  "uusd": "0.015",
  "ukrw": "0.015",
  "umnt": "0.015"
}
```