### PR TITLE
Fix/tax cap rate fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcd",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Terra FCD API Server",
   "main": "index.js",
   "author": "Terra Engineering <engineering@terra.money>",

--- a/src/lib/lcd.ts
+++ b/src/lib/lcd.ts
@@ -366,9 +366,11 @@ export function getSeigniorageProceeds(): Promise<string> {
 }
 
 export async function getTaxRate(height?: string): Promise<string> {
-  return get(`/treasury/tax_rate`, height ? { height } : undefined)
+  const taxRate = await get(`/treasury/tax_rate`, height ? { height } : undefined)
+  return taxRate ? taxRate : get(`/treasury/tax_rate`) // fallback for col-3 to col-4 upgrade
 }
 
 export async function getTaxCap(denom: string, height?: string): Promise<string> {
-  return get(`/treasury/tax_cap/${denom}`, height ? { height } : undefined)
+  const taxCaps = await get(`/treasury/tax_cap/${denom}`, height ? { height } : undefined)
+  return taxCaps ? taxCaps : get(`/treasury/tax_cap/${denom}`) // fallback for col-3 to col-4 upgrade
 }


### PR DESCRIPTION
Add fallback for tax cap and tax rate if collector stopped for long time.
In col-4 tx data doesn't contains the tax_rate and tax_cap info. FCD need to get those info from `/treasury/tax_rate?height=` and `/treasury/tax_cap/{denom}?height=`. LCD keeps data of last 1000 height. so those data will be unavailable if collector stopped for long time. in that case it will use current tax_rate and tax_caps from lcd. 