### PR TITLE
fix: handle getOnedayBefore() with added denoms

### DIFF
--- a/src/service/market/helper.ts
+++ b/src/service/market/helper.ts
@@ -28,7 +28,7 @@ export async function getOnedayBefore(): Promise<CoinByDenoms> {
       datetime: 'DESC'
     },
     skip: 0,
-    take: 10
+    take: 20
   })
 
   return denomPrices.reduce((acc, curr) => {


### PR DESCRIPTION
All other denoms are added, but from db we're pulling 10 entries max. This results in USD calculations wrong


# Before
```
[
  {
    denom: 'uluna',
    swaprate: '0.45543509565190272275',
    oneDayVariation: '0',
    oneDayVariationRate: '0'
  },
  {
    denom: 'uaud',
    swaprate: '1.31149324084698633161',
    oneDayVariation: '-1.19894554871957366839',
    oneDayVariationRate: '-0.47758405968805863744'
  },
  {
    denom: 'ucad',
    swaprate: '1.27628140805388237764',
    oneDayVariation: '-1.16959600323380762236',
    oneDayVariationRate: '-0.47819077024716710942'
  },
  {
    denom: 'uchf',
    swaprate: '0.8964650931364280216',
    oneDayVariation: '-0.8144556053702419784',
    oneDayVariationRate: '-0.47603352164779882392'
  },
  {
    denom: 'ucny',
    swaprate: '6.44954163083288957605',
    oneDayVariation: '-5.85025369943521042395',
    oneDayVariationRate: '-0.47563829660145180616'
  },
  {
    denom: 'ueur',
    swaprate: '0.83033514475707693622',
    oneDayVariation: '-0.75192292320928306378',
    oneDayVariationRate: '-0.47522141832129340881'
  },
  {
    denom: 'ugbp',
    swaprate: '0.73111573271674759674',
    oneDayVariation: '-0.66556401036683240326',
    oneDayVariationRate: '-0.4765330160065218142'
  },
  {
    denom: 'uhkd',
    swaprate: '7.73969411322622262932',
    oneDayVariation: '-7.02436889098777737068',
    oneDayVariationRate: '-0.47577478428416774093'
  },
  {
    denom: 'uinr',
    swaprate: '72.82623786520426656797',
    oneDayVariation: '-66.16476383248773343203',
    oneDayVariationRate: '-0.4760363118786446248'
  },
  {
    denom: 'ujpy',
    swaprate: '104.86763084634384130294',
    oneDayVariation: '-95.19772651207515869706',
    oneDayVariationRate: '-0.47583313657610158724'
  },
  {
    denom: 'ukrw',
    swaprate: '1111.11111111111100001916',
    oneDayVariation: '-1010.23315145135899998084',
    oneDayVariationRate: '-0.47622310498110833748'
  },
  {
    denom: 'umnt',
    swaprate: '2857.14285714285729719206',
    oneDayVariation: '0',
    oneDayVariationRate: '0'
  },
  {
    denom: 'usdr',
    swaprate: '0.6952555759497190455',
    oneDayVariation: '0',
    oneDayVariationRate: '0'
  },
  {
    denom: 'usgd',
    swaprate: '1.32959326502178901159',
    oneDayVariation: '0',
    oneDayVariationRate: '0'
  }
]
```


# After fix
```
[
  {
    denom: 'uluna',
    swaprate: '0.45584220672913646336',
    oneDayVariation: '-0.06793468828975607455',
    oneDayVariationRate: '-0.12970157510919927582'
  },
  {
    denom: 'uaud',
    swaprate: '1.31166004556352024735',
    oneDayVariation: '-0.00324978877063950529',
    oneDayVariationRate: '-0.00247149172192869327'
  },
  {
    denom: 'ucad',
    swaprate: '1.27649838491821084363',
    oneDayVariation: '-0.00459569116290220801',
    oneDayVariationRate: '-0.00358731747239086425'
  },
  {
    denom: 'uchf',
    swaprate: '0.89658593707497252127',
    oneDayVariation: '0.00044520598759413772',
    oneDayVariationRate: '0.0004968036516473525'
  },
  {
    denom: 'ucny',
    swaprate: '6.44986971184978012155',
    oneDayVariation: '0.00752110439408083642',
    oneDayVariationRate: '0.00116744759595540952'
  },
  {
    denom: 'ueur',
    swaprate: '0.83033514475643012545',
    oneDayVariation: '0.00158492679841824966',
    oneDayVariationRate: '0.00191243002303324765'
  },
  {
    denom: 'ugbp',
    swaprate: '0.73123425792335857684',
    oneDayVariation: '-0.00031432124474350604',
    oneDayVariationRate: '-0.00042966558024204482'
  },
  {
    denom: 'uhkd',
    swaprate: '7.73971377643623607848',
    oneDayVariation: '0.00663869822572462292',
    oneDayVariationRate: '0.0008584810257992303'
  },
  {
    denom: 'uinr',
    swaprate: '72.82944254902453397801',
    oneDayVariation: '0.02916724424179678276',
    oneDayVariationRate: '0.00040064744425328555'
  },
  {
    denom: 'ujpy',
    swaprate: '104.88526188257448847138',
    oneDayVariation: '0.09565020453664019374',
    oneDayVariationRate: '0.00091278327121319869'
  },
  {
    denom: 'ukrw',
    swaprate: '1111.11111111111100025697',
    oneDayVariation: '-1.85677712e-12',
    oneDayVariationRate: '-1.6711e-15'
  },
  {
    denom: 'umnt',
    swaprate: '2857.14285714285729780357',
    oneDayVariation: '-5.08282252e-12',
    oneDayVariationRate: '-1.77899e-15'
  },
  {
    denom: 'usdr',
    swaprate: '0.69525557594971902895',
    oneDayVariation: '0.0005120058014581628',
    oneDayVariationRate: '0.00073697091050284763'
  },
  {
    denom: 'usgd',
    swaprate: '1.32966501831259299701',
    oneDayVariation: '0.00215963672930782581',
    oneDayVariationRate: '0.00162683839875065267'
  }
]
```