### PR TITLE
Avoid airdrop staking return volatility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "fcd",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.8.1",
+      "version": "0.8.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcd",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Terra FCD Suite",
   "main": "index.js",
   "author": "Terra Engineering <engineering@terra.money>",

--- a/src/service/dashboard/getStakingReturn.ts
+++ b/src/service/dashboard/getStakingReturn.ts
@@ -58,7 +58,7 @@ export async function getAirdropAnnualAvgReturn(): Promise<string> {
   const { avgReturn } = await getRepository(DashboardEntity)
     .createQueryBuilder()
     .select('SUM(airdrop / avg_staking) * 365 / COUNT(*)', 'avgReturn')
-    .where('timestamp >= :date', { date: subDays(startOfToday(), 30) })
+    .where('timestamp >= :date', { date: subDays(startOfToday(), 36) })
     .getRawOne()
 
   return avgReturn

--- a/src/service/dashboard/getStakingReturn.ts
+++ b/src/service/dashboard/getStakingReturn.ts
@@ -58,7 +58,7 @@ export async function getAirdropAnnualAvgReturn(): Promise<string> {
   const { avgReturn } = await getRepository(DashboardEntity)
     .createQueryBuilder()
     .select('SUM(airdrop / avg_staking) * 365 / COUNT(*)', 'avgReturn')
-    .where('timestamp >= :date', { date: subDays(startOfToday(), 36) })
+    .where('timestamp >= :date', { date: subDays(startOfToday(), 33) })
     .getRawOne()
 
   return avgReturn

--- a/src/service/staking/getValidators.ts
+++ b/src/service/staking/getValidators.ts
@@ -12,7 +12,7 @@ SELECT operator_address,
   SUM((reward - commission) / avg_voting_power) * 365 / COUNT(*) AS annual_return,
   COUNT(*) AS data_point_count
 FROM validator_return_info
-WHERE timestamp >= DATE(now() - INTERVAL '30 day')
+WHERE timestamp >= DATE(NOW() - INTERVAL '30 day')
 AND avg_voting_power > 0
 GROUP BY operator_address;`
 


### PR DESCRIPTION
## Description
Validator delegation return formula is calculating average over 30 days of staking return for each validator. However, MIR Airdrop happens every 100,000 blocks and approximately it's a one week. To mitigate the volatility of delegation return, we look for 33 days for Airdrop instead of 30.
