### PR TITLE
feat(service/tx/parseMsg): handle correct tense when failed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "bignumber.js": "^9.0.1",
         "bluebird": "^3.7.2",
         "byline": "^5.0.0",
+        "compromise": "^13.11.2",
         "date-fns": "^1.30.1",
         "date-fns-timezone": "^0.1.4",
         "globby": "^11.0.1",
@@ -3152,6 +3153,17 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "node_modules/compromise": {
+      "version": "13.11.2",
+      "resolved": "https://registry.npmjs.org/compromise/-/compromise-13.11.2.tgz",
+      "integrity": "sha512-sAASylAtghacJm3tTIF2AyekjxNMGyWaIsQ3sDdJT1UcIa6mC7VbNLQBI3eSBitf+LwrvZTgrY1nWOetY4SScw==",
+      "dependencies": {
+        "efrt-unpack": "2.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3631,6 +3643,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "node_modules/efrt-unpack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/efrt-unpack/-/efrt-unpack-2.2.0.tgz",
+      "integrity": "sha512-9xUSSj7qcUxz+0r4X3+bwUNttEfGfK5AH+LVa1aTpqdAfrN5VhROYCfcF+up4hp5OL7IUKcZJJrzAGipQRDoiQ=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.3.727",
@@ -14692,6 +14709,14 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compromise": {
+      "version": "13.11.2",
+      "resolved": "https://registry.npmjs.org/compromise/-/compromise-13.11.2.tgz",
+      "integrity": "sha512-sAASylAtghacJm3tTIF2AyekjxNMGyWaIsQ3sDdJT1UcIa6mC7VbNLQBI3eSBitf+LwrvZTgrY1nWOetY4SScw==",
+      "requires": {
+        "efrt-unpack": "2.2.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -15066,6 +15091,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "efrt-unpack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/efrt-unpack/-/efrt-unpack-2.2.0.tgz",
+      "integrity": "sha512-9xUSSj7qcUxz+0r4X3+bwUNttEfGfK5AH+LVa1aTpqdAfrN5VhROYCfcF+up4hp5OL7IUKcZJJrzAGipQRDoiQ=="
     },
     "electron-to-chromium": {
       "version": "1.3.727",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "bignumber.js": "^9.0.1",
     "bluebird": "^3.7.2",
     "byline": "^5.0.0",
+    "compromise": "^13.11.2",
     "date-fns": "^1.30.1",
     "date-fns-timezone": "^0.1.4",
     "globby": "^11.0.1",

--- a/src/service/transaction/parseMsg.spec.ts
+++ b/src/service/transaction/parseMsg.spec.ts
@@ -1,0 +1,7 @@
+import { convertToFailureMessage } from './parseMsg'
+
+test('parseMsg', () => {
+  expect(convertToFailureMessage('Received 9,980.039920 Luna from terra1asdfasdf')).toStrictEqual(
+    'receive 9,980.039920 Luna from terra1asdfasdf'
+  )
+})

--- a/src/service/transaction/parseMsg.ts
+++ b/src/service/transaction/parseMsg.ts
@@ -3,6 +3,7 @@ import getMoniker from 'lib/getMoniker'
 import { splitDenomAndAmount } from 'lib/common'
 import { get } from 'lodash'
 import { getSwapCoinAndFee } from './helper'
+import nlp from 'compromise'
 
 type Params = Transaction.Message & { address?: string; log?: Transaction.Log }
 type Parsed = { tag: string; text: string; tax?: string }
@@ -287,8 +288,12 @@ export default async (
   const parsed: ParsedTxMsgInfo = await parser({ ...message, type, address, log })
 
   if (!success) {
-    parsed.text = `Fail to ${parsed.text}`
+    parsed.text = `Failed to ${convertToFailureMessage(parsed.text || '')}`
   }
 
   return parsed
+}
+
+export function convertToFailureMessage(text: string) {
+  return nlp(text).verbs().toPresentTense().toLowerCase()
 }


### PR DESCRIPTION
- use `compromise` library to correctly handle tx test output tense when the tx failed